### PR TITLE
fix(web): include qualityDisplayOrder in review submit body

### DIFF
--- a/apps/web/src/pages/ReviewPage.tsx
+++ b/apps/web/src/pages/ReviewPage.tsx
@@ -144,6 +144,7 @@ export default function ReviewPage() {
         body: JSON.stringify({
           reviewToken: token || reviewToken,
           qualities: selectedQualities,
+          qualityDisplayOrder: shuffledQualities.map((q) => q.key),
           thumbsUp: true,
         }),
       });


### PR DESCRIPTION
## Summary

Frontend was submitting \`{ reviewToken, qualities, thumbsUp }\` to \`/api/v1/reviews/submit\`, but the server schema (\`submitReviewSchema\`) requires \`qualityDisplayOrder\` — all 5 qualities in the order they were shown. Every customer review after OTP verification was 400ing with 'Submit failed'.

## Why this escaped the integration suite

API integration tests construct request bodies directly (helper includes \`qualityDisplayOrder\`), so the server never refused. The real UI was missing the field. Caught during a post-deploy Playwright run against dev per \`docs/test/dev-testing.md\`.

## Fix

\`apps/web/src/pages/ReviewPage.tsx\` \`handleOtpVerified\`: include \`qualityDisplayOrder: shuffledQualities.map((q) => q.key)\` in the submit body.

## Test plan

- [x] Playwright full happy path against dev: scan → qualities → Submit → phone → OTP (sum=7) → **Review saved!**
- [x] All 6 seeded profiles' QR pages render with 5 quality chips
- [x] 3 public profile pages render
- [x] Dashboard Google sign-in page renders
- [x] 11/11 Playwright checks green against \`review-web-dev-00008\`