### PR TITLE
fix(ci/deploy): restore CI deploy pipeline (env injection + accessor-only SA)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
     # iepapp/.github/workflows/deploy-api.yml.
     env:
       # ── GCP ────────────────────────────────────────────────
+      # Skip Secret Manager upserts (CI SA only has accessor role).
+      # Run `task dev:sync:vault` from a maintainer's machine to populate.
+      SKIP_SECRET_SYNC: "true"
       GCP_PROJECT_ID:                    ${{ secrets.GCP_PROJECT_ID }}
       GCP_REGION:                        asia-southeast1
       CLOUDSQL_CONNECTION_NAME:          ${{ secrets.CLOUDSQL_CONNECTION_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,16 +40,72 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    # Secrets -> job env vars. deploy.js overlays these on top of whatever
+    # .env.<env> has (empty in CI, real file locally). Pattern lifted from
+    # iepapp/.github/workflows/deploy-api.yml.
     env:
-      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GCP_REGION: asia-southeast1
-      CLOUDSQL_CONNECTION_NAME: ${{ secrets.CLOUDSQL_CONNECTION_NAME }}
+      # ── GCP ────────────────────────────────────────────────
+      GCP_PROJECT_ID:                    ${{ secrets.GCP_PROJECT_ID }}
+      GCP_REGION:                        asia-southeast1
+      CLOUDSQL_CONNECTION_NAME:          ${{ secrets.CLOUDSQL_CONNECTION_NAME }}
+      # ── Postgres (Cloud SQL via socket in Cloud Run) ──────
+      POSTGRES_DB:                       ${{ secrets.POSTGRES_DB }}
+      POSTGRES_USER:                     ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD:                 ${{ secrets.POSTGRES_PASSWORD }}
+      # ── Auth ──────────────────────────────────────────────
+      JWT_SECRET:                        ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRATION_TIME_IN_MINUTES:    ${{ secrets.JWT_EXPIRATION_TIME_IN_MINUTES || '60' }}
+      # ── Firebase / GCS ────────────────────────────────────
+      FIREBASE_PROJECT_ID:               ${{ secrets.FIREBASE_PROJECT_ID }}
+      GCP_BUCKET_NAME:                   ${{ secrets.GCP_BUCKET_NAME }}
+      SIGNED_URL_EXPIRY_MINUTES:         ${{ secrets.SIGNED_URL_EXPIRY_MINUTES || '60' }}
+      # ── Stripe (test mode on dev) ─────────────────────────
+      STRIPE_SECRET_KEY:                 ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_PUBLISHABLE_KEY:            ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+      STRIPE_WEBHOOK_SECRET:             ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      STRIPE_PRODUCT_PRO:                ${{ secrets.STRIPE_PRODUCT_PRO }}
+      STRIPE_PRODUCT_EMPLOYER:           ${{ secrets.STRIPE_PRODUCT_EMPLOYER }}
+      STRIPE_PRODUCT_RECRUITER:          ${{ secrets.STRIPE_PRODUCT_RECRUITER }}
+      STRIPE_PRICE_PRO_MONTHLY:          ${{ secrets.STRIPE_PRICE_PRO_MONTHLY }}
+      STRIPE_PRICE_PRO_ANNUAL:           ${{ secrets.STRIPE_PRICE_PRO_ANNUAL }}
+      STRIPE_PRICE_EMPLOYER_SMALL:       ${{ secrets.STRIPE_PRICE_EMPLOYER_SMALL }}
+      STRIPE_PRICE_EMPLOYER_MEDIUM:      ${{ secrets.STRIPE_PRICE_EMPLOYER_MEDIUM }}
+      STRIPE_PRICE_EMPLOYER_LARGE:       ${{ secrets.STRIPE_PRICE_EMPLOYER_LARGE }}
+      STRIPE_PRICE_RECRUITER_BASIC:      ${{ secrets.STRIPE_PRICE_RECRUITER_BASIC }}
+      STRIPE_PRICE_RECRUITER_PREMIUM:    ${{ secrets.STRIPE_PRICE_RECRUITER_PREMIUM }}
+      # ── SMS (mocked on dev) ───────────────────────────────
+      SMS_PROVIDER:                      ${{ secrets.SMS_PROVIDER || 'mock' }}
+      # ── App URLs / CORS ───────────────────────────────────
+      APP_URL:                           ${{ secrets.APP_URL || 'https://review-api.teczeed.com' }}
+      APP_BASE_URL:                      ${{ secrets.APP_BASE_URL || 'https://review-api.teczeed.com' }}
+      API_BASE_URL:                      ${{ secrets.API_BASE_URL || 'https://review-api.teczeed.com' }}
+      FRONTEND_URL:                      ${{ secrets.FRONTEND_URL || 'https://review-scan.teczeed.com' }}
+      CORS_ORIGINS:                      ${{ secrets.CORS_ORIGINS || 'https://review-scan.teczeed.com,https://review-dashboard.teczeed.com,https://review-profile.teczeed.com' }}
+      # ── Review policy ─────────────────────────────────────
+      REVIEW_TOKEN_EXPIRY_HOURS:         ${{ secrets.REVIEW_TOKEN_EXPIRY_HOURS || '48' }}
+      REVIEW_COOLDOWN_DAYS:              ${{ secrets.REVIEW_COOLDOWN_DAYS || '7' }}
+      ENABLE_HTTP_LOGGING:               ${{ secrets.ENABLE_HTTP_LOGGING || 'false' }}
+      # ── Vite build-time args (web/ui) ─────────────────────
+      VITE_API_URL:                      ${{ secrets.VITE_API_URL || 'https://review-api.teczeed.com' }}
+      VITE_FIREBASE_API_KEY:             ${{ secrets.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN:         ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID:          ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET:      ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
+      VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Remove .env files
-        run: find . -name ".env*" -type f -delete && touch .env .env.dev
+      # Wipe any .env files that may have slipped in, then create empty
+      # placeholders so local-dev code paths that `fs.existsSync('.env')`
+      # don't trip. Real config comes from the `env:` block above.
+      - name: Remove all .env files
+        run: |
+          find . -name ".env*" -type f -print -delete
+          touch .env
+          touch .env.dev
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Remove .env files
-        run: find . -name ".env*" -type f -delete && touch .env
+        run: find . -name ".env*" -type f -delete && touch .env .env.dev
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/infra/dev/vault
+++ b/infra/dev/vault
@@ -1,0 +1,1 @@
+/Users/muthuishere/muthu/gitworkspace/bossbroprojects/review-workspace/review-app/infra/dev/vault

--- a/infra/dev/vault
+++ b/infra/dev/vault
@@ -1,1 +1,0 @@
-/Users/muthuishere/muthu/gitworkspace/bossbroprojects/review-workspace/review-app/infra/dev/vault

--- a/infra/scripts/deploy.js
+++ b/infra/scripts/deploy.js
@@ -105,46 +105,88 @@ function timestamp() {
 const SECTION_HEADER_RE =
   /^#+\s*#{3,}\s*(GCP Vault Files|GitHub Vault Files|GCP Secrets|GitHub Secrets|Both|Local)\s*#{3,}/i;
 
+// Keys deploy.js understands. Used for the process.env overlay when
+// running in CI where .env.<env> is empty/absent and secrets come in
+// as job-level env vars (see .github/workflows/deploy.yml).
+const KNOWN_CONFIG_KEYS = [
+  'NODE_ENV',
+  'GCP_PROJECT_ID', 'GCP_REGION', 'CLOUDSQL_CONNECTION_NAME',
+  'POSTGRES_HOST', 'POSTGRES_PORT', 'POSTGRES_DB', 'POSTGRES_USER', 'POSTGRES_PASSWORD',
+  'JWT_SECRET', 'JWT_EXPIRATION_TIME_IN_MINUTES',
+  'FIREBASE_PROJECT_ID', 'FIREBASE_SERVICE_ACCOUNT_PATH',
+  'GCP_BUCKET_NAME', 'SIGNED_URL_EXPIRY_MINUTES',
+  'STRIPE_SECRET_KEY', 'STRIPE_PUBLISHABLE_KEY', 'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_PRODUCT_PRO', 'STRIPE_PRODUCT_EMPLOYER', 'STRIPE_PRODUCT_RECRUITER',
+  'STRIPE_PRICE_PRO_MONTHLY', 'STRIPE_PRICE_PRO_ANNUAL',
+  'STRIPE_PRICE_EMPLOYER_SMALL', 'STRIPE_PRICE_EMPLOYER_MEDIUM', 'STRIPE_PRICE_EMPLOYER_LARGE',
+  'STRIPE_PRICE_RECRUITER_BASIC', 'STRIPE_PRICE_RECRUITER_PREMIUM',
+  'SMS_PROVIDER',
+  'APP_BASE_URL', 'API_BASE_URL', 'APP_URL', 'FRONTEND_URL', 'CORS_ORIGINS',
+  'REVIEW_TOKEN_EXPIRY_HOURS', 'REVIEW_COOLDOWN_DAYS',
+  'ENABLE_HTTP_LOGGING',
+  'EXPO_TOKEN',
+  'VITE_API_URL',
+  'VITE_FIREBASE_API_KEY', 'VITE_FIREBASE_AUTH_DOMAIN', 'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_STORAGE_BUCKET', 'VITE_FIREBASE_MESSAGING_SENDER_ID',
+  'VITE_FIREBASE_APP_ID', 'VITE_FIREBASE_MEASUREMENT_ID',
+];
+
 function loadEnvFile(env) {
   const filePath = path.join(ROOT_DIR, `.env.${env}`);
-  if (!fs.existsSync(filePath)) {
-    console.error(`Missing env file: ${filePath}`);
-    process.exit(1);
-  }
   const result = {};
   const gcpVaultFiles = {}; // KEY → local path (repo-root-resolved)
-  let section = null;
-  const lines = fs.readFileSync(filePath, 'utf8').split('\n');
-  for (const raw of lines) {
-    const line = raw.trim();
 
-    const header = line.match(SECTION_HEADER_RE);
-    if (header) {
-      const n = header[1].toLowerCase();
-      if (n.startsWith('gcp vault')) section = 'gcp_vault';
-      else if (n.startsWith('github vault')) section = 'gh_vault';
-      else section = 'other';
-      continue;
-    }
+  if (fs.existsSync(filePath)) {
+    let section = null;
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+    for (const raw of lines) {
+      const line = raw.trim();
 
-    if (!line || line.startsWith('#')) continue;
-    const eq = line.indexOf('=');
-    if (eq === -1) continue;
-    const key = line.slice(0, eq).trim();
-    let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    result[key] = value;
+      const header = line.match(SECTION_HEADER_RE);
+      if (header) {
+        const n = header[1].toLowerCase();
+        if (n.startsWith('gcp vault')) section = 'gcp_vault';
+        else if (n.startsWith('github vault')) section = 'gh_vault';
+        else section = 'other';
+        continue;
+      }
 
-    if (section === 'gcp_vault' && key.endsWith('_PATH')) {
-      const stripped = value.startsWith('../../') ? value.slice(6) : value;
-      gcpVaultFiles[key] = path.resolve(ROOT_DIR, stripped);
+      if (!line || line.startsWith('#')) continue;
+      const eq = line.indexOf('=');
+      if (eq === -1) continue;
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      result[key] = value;
+
+      if (section === 'gcp_vault' && key.endsWith('_PATH')) {
+        const stripped = value.startsWith('../../') ? value.slice(6) : value;
+        gcpVaultFiles[key] = path.resolve(ROOT_DIR, stripped);
+      }
     }
   }
+
+  // Overlay process.env for known keys (CI path — secrets injected as
+  // job-level env vars). process.env wins over file so CI can override.
+  for (const key of KNOWN_CONFIG_KEYS) {
+    const v = process.env[key];
+    if (v !== undefined && v !== '') {
+      result[key] = v;
+    }
+  }
+
+  if (Object.keys(result).length === 0) {
+    console.error(
+      `No config found: ${filePath} missing and no KNOWN_CONFIG_KEYS present in process.env`,
+    );
+    process.exit(1);
+  }
+
   result.__gcpVaultFiles = gcpVaultFiles;
   return result;
 }

--- a/infra/scripts/deploy.js
+++ b/infra/scripts/deploy.js
@@ -257,6 +257,16 @@ function upsertSecret(secretName, value) {
 }
 
 function syncSecrets(envMap) {
+  // In CI, the deployer SA typically only has `secretmanager.secretAccessor`
+  // — enough to reference secrets from Cloud Run but not to create/update
+  // them. Set SKIP_SECRET_SYNC=true in the workflow to skip upserts and
+  // assume sync-vault.ts (run from a human's machine with admin perms)
+  // has already populated Secret Manager.
+  if (process.env.SKIP_SECRET_SYNC === 'true') {
+    console.log('\n>>> Skip Secret Manager sync (SKIP_SECRET_SYNC=true)');
+    requireKeys(envMap, Object.keys(SECRET_MAPPING), 'secrets');
+    return;
+  }
   console.log(`\n>>> Sync secrets to GCP Secret Manager (project=${GCP_PROJECT})`);
   requireKeys(envMap, Object.keys(SECRET_MAPPING), 'secrets');
   for (const [envVar, secretName] of Object.entries(SECRET_MAPPING)) {


### PR DESCRIPTION
## Summary
- Restore orphaned fix from `63e3c25`: inject dev secrets as job env vars and overlay `process.env` in `deploy.js` via `KNOWN_CONFIG_KEYS`, so CI doesn't need a committed `.env.dev`.
- Add `SKIP_SECRET_SYNC=true` — the CI deployer SA only has `secretmanager.secretAccessor`; secret writes stay on `task dev:sync:vault` (run from a maintainer's machine).

## Why
Deploy workflow has been failing on `main` since Apr 17 (`Missing env file: .env.dev`), which left dev running a pre-spec-19-B2 build. After this PR the workflow runs green and dev returns `name: "Ramesh Kumar"` + `headline: "Senior Sales Consultant"` as spec 19 B2 intended.

## Test plan
- [x] `gh workflow run deploy.yml` on `bugfixes-dev` → green (run 24602637702)
- [x] `curl https://review-api.teczeed.com/api/v1/profiles/ramesh-kumar` returns split `name`/`headline`
- [ ] Re-run deploy from `main` after merge