### PR TITLE
fix: tsc build breaks + add local:build tasks for web/ui

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ Key tasks:
 - `local:bootstrap` — first-run setup: `infra:up` + wait-healthy + `migrate` + `seed`
 - `local:dev` — day-to-day: ensure infra up, start API dev server
 - `local:infra:up | down | reset | ps | wait` — manage the local docker-compose stack
-- `local:server | migrate | seed | psql | test | build` — individual ops (thin wrappers over `infra/scripts/run.sh local …`)
+- `local:server | migrate | seed | psql | test | build` — individual API ops (thin wrappers over `infra/scripts/run.sh local …`)
+- `local:build:web | build:ui` — tsc + vite build check for the two frontends (mirrors the Cloud Run build step; use before pushing to catch build breaks that only show up in the deploy container)
 - `local:stripe:listen` — forward Stripe webhooks to local API
 
 **Dev** (deploys to GCP, reads `.env.dev`):

--- a/Taskfile.local.yml
+++ b/Taskfile.local.yml
@@ -95,5 +95,19 @@ tasks:
     cmd: "{{.REPO_ROOT}}/infra/scripts/run.sh local test"
 
   build:
-    desc: TypeScript build check
+    desc: TypeScript build check (API)
     cmd: "{{.REPO_ROOT}}/infra/scripts/run.sh local build"
+
+  build:web:
+    desc: tsc + vite build check for apps/web (mirrors the Cloud Run build step)
+    env:
+      APP_ENV: '{{.APP_ENV | default "local"}}'
+    cmd: |
+      cd {{.REPO_ROOT}}/apps/web && npm run build
+
+  build:ui:
+    desc: tsc + vite build check for apps/ui (mirrors the Cloud Run build step)
+    env:
+      APP_ENV: '{{.APP_ENV | default "local"}}'
+    cmd: |
+      cd {{.REPO_ROOT}}/apps/ui && npm run build

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/test"]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/test"]
 }


### PR DESCRIPTION
Deploy was failing because `tsc -b` pulled config.test.ts → config/load.ts into the program, both of which use node APIs without @types/node.

- Exclude test files from ui/web tsconfig (tests run via vitest).
- Add `local:build:web` + `local:build:ui` tasks so build checks go through task per CLAUDE.md rule.

## Test plan
- [x] `task local:build:web` — green
- [x] `task local:build:ui` — green
- [ ] Cloud Run deploy (all) — verify web + ui build pass in CI