### PR TITLE
fix(api): spec 53 — schema-code drift + 651x local port reorg

### DIFF
--- a/.env
+++ b/.env
@@ -11,11 +11,13 @@
 # ============================================================================
 
 NODE_ENV=development
-PORT=3000
+
+# Local API port (651x range). Cloud Run injects PORT=8080 at runtime separately.
+PORT=6510
 
 # Database
 POSTGRES_HOST=localhost
-POSTGRES_PORT=10032
+POSTGRES_PORT=6519
 POSTGRES_DB=review_app
 POSTGRES_USER=review_user
 POSTGRES_PASSWORD=changeme

--- a/Taskfile.local.yml
+++ b/Taskfile.local.yml
@@ -53,8 +53,22 @@ tasks:
   # ─── Dev Server ──────────────────────────────────────────────────────────────
 
   server:
-    desc: Start API dev server
+    desc: Start API dev server (port from .env PORT, default 6510)
     cmd: "{{.REPO_ROOT}}/infra/scripts/run.sh local server"
+
+  dev:ui:
+    desc: Start UI Vite dev server (port from apps/ui/vite.config.ts, currently 6513)
+    env:
+      APP_ENV: local
+    cmd: |
+      cd {{.REPO_ROOT}}/apps/ui && npx vite
+
+  dev:web:
+    desc: Start Web Vite dev server (port from apps/web/vite.config.ts, currently 6514)
+    env:
+      APP_ENV: local
+    cmd: |
+      cd {{.REPO_ROOT}}/apps/web && npx vite
 
   # ─── Database ────────────────────────────────────────────────────────────────
 
@@ -85,8 +99,8 @@ tasks:
   # ─── Stripe ──────────────────────────────────────────────────────────────────
 
   stripe:listen:
-    desc: Forward Stripe webhooks to local API
-    cmd: stripe listen --forward-to http://localhost:3000/api/v1/subscriptions/webhook
+    desc: Forward Stripe webhooks to local API (PORT from .env)
+    cmd: stripe listen --forward-to http://localhost:${PORT:-6510}/api/v1/subscriptions/webhook
 
   # ─── Quality ─────────────────────────────────────────────────────────────────
 

--- a/apps/api/src/db/migrations/20260420-0002-fix-schema-drift.ts
+++ b/apps/api/src/db/migrations/20260420-0002-fix-schema-drift.ts
@@ -1,0 +1,85 @@
+import type { Migration } from "../umzug.js";
+
+// Spec 53 — patch missing columns/extensions/indexes that the repos write SQL
+// for but no prior migration ever created. Additive only.
+
+export const up: Migration = async ({ context: sequelize }) => {
+  // 1. pg_trgm extension (for `p.location % :query` similarity operator)
+  await sequelize.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+
+  // 2-4. subscriptions: stripe_price_id, billing_cycle, quantity
+  await sequelize.query(`
+    ALTER TABLE subscriptions
+      ADD COLUMN IF NOT EXISTS stripe_price_id varchar(255),
+      ADD COLUMN IF NOT EXISTS billing_cycle   varchar(20),
+      ADD COLUMN IF NOT EXISTS quantity        integer NOT NULL DEFAULT 1
+  `);
+
+  // 5. profiles.search_vector
+  await sequelize.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS search_vector tsvector`);
+
+  // 6. GIN index on search_vector
+  await sequelize.query(`
+    CREATE INDEX IF NOT EXISTS profiles_search_vector_idx
+      ON profiles USING gin (search_vector)
+  `);
+
+  // 7. trigram GIN index on profiles.location
+  await sequelize.query(`
+    CREATE INDEX IF NOT EXISTS profiles_location_trgm_idx
+      ON profiles USING gin (location gin_trgm_ops)
+  `);
+
+  // 8. Backfill search_vector for existing rows
+  await sequelize.query(`
+    UPDATE profiles
+    SET search_vector = to_tsvector(
+      'english',
+      coalesce(headline, '') || ' ' ||
+      coalesce(bio, '')      || ' ' ||
+      coalesce(industry, '') || ' ' ||
+      coalesce(location, '')
+    )
+    WHERE search_vector IS NULL
+  `);
+
+  // 9. Trigger to keep search_vector in sync on INSERT/UPDATE
+  await sequelize.query(`
+    CREATE OR REPLACE FUNCTION profiles_search_vector_refresh()
+    RETURNS trigger AS $$
+    BEGIN
+      NEW.search_vector := to_tsvector(
+        'english',
+        coalesce(NEW.headline, '') || ' ' ||
+        coalesce(NEW.bio, '')      || ' ' ||
+        coalesce(NEW.industry, '') || ' ' ||
+        coalesce(NEW.location, '')
+      );
+      RETURN NEW;
+    END
+    $$ LANGUAGE plpgsql
+  `);
+
+  await sequelize.query(`DROP TRIGGER IF EXISTS profiles_search_vector_trg ON profiles`);
+  await sequelize.query(`
+    CREATE TRIGGER profiles_search_vector_trg
+      BEFORE INSERT OR UPDATE OF headline, bio, industry, location
+      ON profiles
+      FOR EACH ROW EXECUTE FUNCTION profiles_search_vector_refresh()
+  `);
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.query(`DROP TRIGGER IF EXISTS profiles_search_vector_trg ON profiles`);
+  await sequelize.query(`DROP FUNCTION IF EXISTS profiles_search_vector_refresh()`);
+  await sequelize.query(`DROP INDEX IF EXISTS profiles_location_trgm_idx`);
+  await sequelize.query(`DROP INDEX IF EXISTS profiles_search_vector_idx`);
+  await sequelize.query(`ALTER TABLE profiles DROP COLUMN IF EXISTS search_vector`);
+  await sequelize.query(`
+    ALTER TABLE subscriptions
+      DROP COLUMN IF EXISTS quantity,
+      DROP COLUMN IF EXISTS billing_cycle,
+      DROP COLUMN IF EXISTS stripe_price_id
+  `);
+  // pg_trgm: leave installed (other migrations may rely on it later)
+};

--- a/apps/api/src/db/migrations/20260420-0003-fix-schema-drift-followup.ts
+++ b/apps/api/src/db/migrations/20260420-0003-fix-schema-drift-followup.ts
@@ -1,0 +1,20 @@
+import type { Migration } from "../umzug.js";
+
+// Spec 53 follow-up — second pass after first migration uncovered two more
+// missing columns the subscription repo SELECTs and RETURNs.
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.query(`
+    ALTER TABLE subscriptions
+      ADD COLUMN IF NOT EXISTS cancel_at_period_end boolean NOT NULL DEFAULT false,
+      ADD COLUMN IF NOT EXISTS cancelled_at         timestamptz
+  `);
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  await sequelize.query(`
+    ALTER TABLE subscriptions
+      DROP COLUMN IF EXISTS cancelled_at,
+      DROP COLUMN IF EXISTS cancel_at_period_end
+  `);
+};

--- a/apps/api/src/modules/subscription/subscription.model.ts
+++ b/apps/api/src/modules/subscription/subscription.model.ts
@@ -6,9 +6,14 @@ export interface SubscriptionAttributes {
   tier: "free" | "pro" | "employer" | "recruiter";
   stripeCustomerId: string | null;
   stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+  billingCycle: "monthly" | "annual" | null;
+  quantity: number;
   status: "active" | "past_due" | "cancelled" | "trialing" | "incomplete";
   currentPeriodStart: Date | null;
   currentPeriodEnd: Date | null;
+  cancelAtPeriodEnd: boolean;
+  cancelledAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -19,9 +24,14 @@ export class Subscription extends Model<SubscriptionAttributes> implements Subsc
   declare tier: "free" | "pro" | "employer" | "recruiter";
   declare stripeCustomerId: string | null;
   declare stripeSubscriptionId: string | null;
+  declare stripePriceId: string | null;
+  declare billingCycle: "monthly" | "annual" | null;
+  declare quantity: number;
   declare status: "active" | "past_due" | "cancelled" | "trialing" | "incomplete";
   declare currentPeriodStart: Date | null;
   declare currentPeriodEnd: Date | null;
+  declare cancelAtPeriodEnd: boolean;
+  declare cancelledAt: Date | null;
   declare createdAt: Date;
   declare updatedAt: Date;
 }
@@ -63,6 +73,24 @@ export function initSubscriptionModel(sequelize: Sequelize): void {
         unique: true,
         field: "stripe_subscription_id",
       },
+      stripePriceId: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+        field: "stripe_price_id",
+      },
+      billingCycle: {
+        type: DataTypes.STRING(20),
+        allowNull: true,
+        field: "billing_cycle",
+        validate: {
+          isIn: [["monthly", "annual"]],
+        },
+      },
+      quantity: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
       status: {
         type: DataTypes.STRING(20),
         allowNull: false,
@@ -80,6 +108,17 @@ export function initSubscriptionModel(sequelize: Sequelize): void {
         type: DataTypes.DATE,
         allowNull: true,
         field: "current_period_end",
+      },
+      cancelAtPeriodEnd: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: "cancel_at_period_end",
+      },
+      cancelledAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        field: "cancelled_at",
       },
       createdAt: {
         type: DataTypes.DATE,

--- a/apps/ui/config/appconfig.local.json
+++ b/apps/ui/config/appconfig.local.json
@@ -1,6 +1,6 @@
 {
-  "apiUrl": "http://localhost:3000",
-  "publicReviewUrl": "http://localhost:5174",
+  "apiUrl": "http://localhost:6510",
+  "publicReviewUrl": "http://localhost:6514",
   "firebase": {
     "apiKey": "AIzaSyBAQ3fKCEiCn-z7VPG9jEzQ-XA9rCWBvhE",
     "authDomain": "humini-review.firebaseapp.com",

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -8,10 +8,10 @@ export default defineConfig({
   plugins: [react()],
   define: buildDefines(appConfig),
   server: {
-    port: 5173,
+    port: 6513,
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: appConfig.apiUrl,
         changeOrigin: true,
       },
     },

--- a/apps/web/config/appconfig.local.json
+++ b/apps/web/config/appconfig.local.json
@@ -1,6 +1,6 @@
 {
-  "apiUrl": "http://localhost:3000",
-  "publicReviewUrl": "http://localhost:5173",
+  "apiUrl": "http://localhost:6510",
+  "publicReviewUrl": "http://localhost:6514",
   "firebase": {
     "apiKey": "AIzaSyBAQ3fKCEiCn-z7VPG9jEzQ-XA9rCWBvhE",
     "authDomain": "humini-review.firebaseapp.com",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,10 +8,10 @@ export default defineConfig({
   plugins: [react()],
   define: buildDefines(appConfig),
   server: {
-    port: 5173,
+    port: 6514,
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: appConfig.apiUrl,
         changeOrigin: true,
       },
     },

--- a/docs/specs/49-profile-me-allow-all-roles.md
+++ b/docs/specs/49-profile-me-allow-all-roles.md
@@ -1,0 +1,87 @@
+# Spec 49 — `/profiles/me*` must work for EMPLOYER and RECRUITER, not just INDIVIDUAL
+
+**Owner:** Sreyash · **Date:** 2026-04-20 · **Status:** Draft
+**Severity:** Blocker on dev — every non-INDIVIDUAL user sees a red error on `/dashboard`.
+**Related:** Spec 16 (auth), Spec 28 (capabilities), Spec 26 (profile edit UI).
+
+## Problem (live bug on dev)
+
+Logged in as `james@reviewapp.demo` (EMPLOYER) or `rachel@reviewapp.demo` (RECRUITER), opening `https://review-dashboard.teczeed.com/dashboard` shows:
+
+```
+Failed to load profile. Make sure the API server is running.
+API error 403: {"error":"Insufficient permissions","code":"FORBIDDEN"}
+```
+
+The nav still shows the **Dashboard** link for these roles (per spec 28's capability table), so users *expect* it to work. The only role that doesn't 403 is INDIVIDUAL.
+
+## Root cause
+
+Every `/profiles/me*` route in `apps/api/src/modules/profile/profile.routes.ts` is gated with `requireRole(['INDIVIDUAL'])`:
+
+```ts
+profileRouter.get('/me',          authenticate, requireRole(['INDIVIDUAL']), controller.getOwn);
+profileRouter.put('/me',          authenticate, requireRole(['INDIVIDUAL']), …, controller.update);
+profileRouter.patch('/me/visibility', authenticate, requireRole(['INDIVIDUAL']), …, controller.updateVisibility);
+profileRouter.get('/me/qr',       authenticate, requireRole(['INDIVIDUAL']), …, controller.getQrCode);
+profileRouter.get('/me/stats',    authenticate, requireRole(['INDIVIDUAL']), …, controller.getStats);
+```
+
+A profile is owned by *the user*, not by their role. Every authenticated user has one (auto-created on signup) and every role's dashboard reads from it.
+
+## Fix
+
+Drop the role gate on every `/profiles/me*` route. Keep `authenticate`. Don't touch `POST /profiles` (creation is still INDIVIDUAL-only because EMPLOYER/RECRUITER profiles are seeded by a different path).
+
+```ts
+// Before
+profileRouter.get('/me', authenticate, requireRole(['INDIVIDUAL']), controller.getOwn);
+// After
+profileRouter.get('/me', authenticate, controller.getOwn);
+```
+
+Apply to all five `/me*` routes (`get /me`, `put /me`, `patch /me/visibility`, `get /me/qr`, `get /me/stats`).
+
+## GIVEN / WHEN / THEN
+
+- **GIVEN** an authenticated EMPLOYER **WHEN** they `GET /api/v1/profiles/me` **THEN** the API returns 200 with their profile (not 403).
+- **GIVEN** an authenticated RECRUITER **WHEN** they `GET /api/v1/profiles/me` **THEN** the API returns 200 with their profile.
+- **GIVEN** an authenticated ADMIN **WHEN** they `GET /api/v1/profiles/me` **THEN** the API returns 200 (admin already worked because of the bypass; keep it green).
+- **GIVEN** an authenticated INDIVIDUAL **WHEN** they `GET /api/v1/profiles/me` **THEN** the API still returns 200 (regression check).
+- **GIVEN** an unauthenticated request **WHEN** it hits `/api/v1/profiles/me` **THEN** the API returns 401 (unchanged).
+- **GIVEN** any authenticated user opens `/dashboard` on the UI **THEN** the profile card renders without the red "API error 403" banner.
+
+## Slice checklist
+
+### API
+- [ ] Remove `requireRole(['INDIVIDUAL'])` from the five `/me*` routes in `apps/api/src/modules/profile/profile.routes.ts`. Keep `authenticate`. Keep `requireRole` on `POST /` (create).
+- [ ] L2 unit: verify each `/me*` route's middleware chain via a small route-introspection test, OR L3 integration covering the GIVEN/WHEN/THEN above.
+- [ ] L3 integration (Testcontainers, in `apps/api/`):
+  - Seed an EMPLOYER user with a profile row, hit `GET /profiles/me` with their JWT, assert 200 + correct profile.
+  - Same for RECRUITER.
+  - INDIVIDUAL still 200.
+
+### Regression
+- [ ] `apps/regression/src/flows/02-dashboard-login.spec.ts` — extend so each of `james@`, `rachel@`, `ramesh@` logs in and the dashboard renders without the "Failed to load profile" string. Failing assertion should be `expect(page.locator('text=Failed to load profile')).not.toBeVisible()`.
+
+### Deploy
+- [ ] `task dev:deploy:api`. Hit `https://review-dashboard.teczeed.com/dashboard` as james + rachel, confirm no 403.
+
+## Invariants
+
+- Auth still required for every `/me*` route.
+- `POST /profiles` (create) stays INDIVIDUAL-only.
+- Public `GET /profiles/:slug` is unchanged.
+- No schema/migration changes.
+
+## Files
+
+- `apps/api/src/modules/profile/profile.routes.ts` (only file with required code change)
+- `apps/api/src/**/__tests__/` (new integration test or extension)
+- `apps/regression/src/flows/02-dashboard-login.spec.ts` (extend coverage)
+
+## Don't touch
+
+- `requireCapability` middleware — unrelated, used for paid features, not basic profile read.
+- `apps/web/`, `apps/mobile/`, billing, employer, recruiter modules.
+- Profile creation rules.

--- a/docs/specs/50-recruiter-blocks-missing-migration.md
+++ b/docs/specs/50-recruiter-blocks-missing-migration.md
@@ -1,0 +1,117 @@
+# Spec 50 — Recruiter search 500: missing `recruiter_blocks` table
+
+**Owner:** Harsh · **Date:** 2026-04-20 · **Status:** Draft
+**Severity:** Blocker — entire Recruiter feature is dead on dev (and almost certainly local + prod, depending on whether anyone has ever shipped this migration).
+**Related:** Spec 12 (recruiter search), Spec 13 (recruiter contact), Spec 28 (capabilities).
+
+## Problem (live bug on dev)
+
+Logged in as `rachel@reviewapp.demo` (RECRUITER), opening `/recruiter` and typing any query (e.g. `ramesh`) immediately shows:
+
+```
+Search failed. Please try again.
+```
+
+Direct API call confirms the server-side error:
+
+```bash
+curl -X POST https://review-api.teczeed.com/api/v1/recruiter/search \
+  -H "authorization: Bearer <rachel-jwt>" \
+  -H "content-type: application/json" \
+  -d '{"query":"ramesh"}'
+
+{"error":"relation \"recruiter_blocks\" does not exist","traceId":"ff4fa538-…"}
+```
+
+## Root cause
+
+Code references `recruiter_blocks` in `apps/api/src/modules/recruiter/recruiter.repo.ts` and `recruiter.service.ts` (used by the search query to filter out blocked individuals). **No migration creates this table.** Existing `20260414-0008-create-recruiter.ts` only creates `recruiter_searches`, `contact_requests`, `fraud_flags`, `qualities`, `quality_scores` — not `recruiter_blocks`.
+
+Verify:
+```bash
+rg -n "createTable.*recruiter_blocks" apps/api/src/db/migrations/   # → no hits
+rg -n "recruiter_blocks" apps/api/src/modules/recruiter/             # → repo + service hits
+```
+
+So the search SQL joins/excludes against a table that never got created — Postgres returns "relation does not exist" → service throws → controller returns 500.
+
+## Fix
+
+Add a new migration that creates the `recruiter_blocks` table and ship it.
+
+### Inferred schema (read code first; this is the starting hypothesis, not a spec)
+
+```sql
+CREATE TABLE recruiter_blocks (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recruiter_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  blocked_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  reason      text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (recruiter_id, blocked_user_id)
+);
+CREATE INDEX recruiter_blocks_recruiter_idx ON recruiter_blocks (recruiter_id);
+CREATE INDEX recruiter_blocks_blocked_idx   ON recruiter_blocks (blocked_user_id);
+```
+
+**Read `recruiter.repo.ts` + `recruiter.service.ts` before finalising the schema** — use whatever columns the existing queries actually reference. Don't add columns the code doesn't read.
+
+## GIVEN / WHEN / THEN
+
+- **GIVEN** a fresh dev DB **WHEN** `task local:migrate` runs **THEN** `recruiter_blocks` table exists with the columns the repo queries reference.
+- **GIVEN** Rachel is logged in **WHEN** she POSTs `/api/v1/recruiter/search` with `{"query":"ramesh"}` **THEN** the API returns 200 with a result list, not 500.
+- **GIVEN** Rachel is logged in **WHEN** she opens `/recruiter` and types `ramesh` **THEN** the result list shows Ramesh Kumar with a Contact button (matches doc Journey 5).
+- **GIVEN** a recruiter has blocked a user **WHEN** they search **THEN** the blocked user does not appear in the result set.
+- **GIVEN** the migration is applied to dev **WHEN** `task dev:logs` is tailed during a recruiter search **THEN** no "relation … does not exist" error appears.
+
+## Slice checklist
+
+### Migration
+- [ ] New file `apps/api/src/db/migrations/20260420-0001-create-recruiter-blocks.ts` (Umzug, mirrors style of `20260414-0008-create-recruiter.ts`).
+- [ ] `up()` creates table + indexes; `down()` drops cleanly.
+- [ ] Run `task local:migrate` against local Postgres → verify table exists via `task local:psql -c '\d recruiter_blocks'`.
+
+### API verification
+- [ ] L2 unit: existing recruiter service tests still pass (no behaviour change yet).
+- [ ] L3 integration: `apps/api/src/modules/recruiter/__tests__/recruiter.search.test.ts` — seed users + a `recruiter_blocks` row, hit `POST /recruiter/search`, assert (a) blocked user excluded from results, (b) non-blocked returned.
+- [ ] If blocking is referenced but the API has no insert path yet, file a follow-up spec — do **not** invent a new endpoint here. The fix is just to make the table exist so search stops 500-ing.
+
+### Regression
+- [ ] `apps/regression/src/flows/19-recruiter-search-results.spec.ts` — add an explicit assertion: search for `ramesh` returns at least 1 result + the result list does NOT contain the literal string "Search failed".
+
+### Deploy
+- [ ] `task dev:migrate` (Cloud SQL Auth Proxy + Umzug) before `task dev:deploy:api`.
+- [ ] After deploy, manually verify in browser as Rachel — `/recruiter` → search "ramesh" → see result.
+
+## Invariants
+
+- Migration is **additive only** — no other tables touched.
+- No new endpoints in this spec. Insert/list/delete of blocks belongs to a future spec.
+- Don't change the search endpoint contract — same request/response shape.
+
+## Files
+
+- `apps/api/src/db/migrations/20260420-0001-create-recruiter-blocks.ts` (new)
+- `apps/api/src/modules/recruiter/__tests__/` (new or extended)
+- `apps/regression/src/flows/19-recruiter-search-results.spec.ts` (extend assertion)
+
+## Don't touch
+
+- `apps/api/src/modules/recruiter/recruiter.service.ts` SQL — leave the query as-is; it was correct, the table was just missing.
+- `apps/ui/src/pages/RecruiterPage.tsx` — UI is fine, it surfaces the error correctly. Don't muffle real errors.
+- Any other module's migrations.
+
+## Verification one-liner
+
+After the migration is live, this should return 200 with results, not 500:
+
+```bash
+TOKEN=$(curl -s -X POST https://review-api.teczeed.com/api/v1/auth/login \
+  -H "content-type: application/json" \
+  -d '{"email":"rachel@reviewapp.demo","password":"Demo123"}' | jq -r .accessToken)
+
+curl -s -X POST https://review-api.teczeed.com/api/v1/recruiter/search \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"query":"ramesh"}' | jq .
+```

--- a/docs/specs/51-billing-plan-switch-via-portal.md
+++ b/docs/specs/51-billing-plan-switch-via-portal.md
@@ -1,0 +1,117 @@
+# Spec 51 — Billing: switching plans on an active sub must work, not 409
+
+**Owner:** Hari · **Date:** 2026-04-20 · **Status:** Draft
+**Severity:** High — every existing subscriber sees an "Upgrade" button that does nothing.
+**Related:** Spec 11 (plans), Spec 28 (capabilities), Spec 48 (capability-as-truth billing redesign).
+
+## Problem (live bug on dev)
+
+Logged in as `ramesh@reviewapp.demo` (currently on Pro Individual, status `active`):
+
+1. Open `/billing`.
+2. Click **Upgrade** on any other plan card (e.g. Employer Medium).
+3. UI surfaces:
+
+```
+API 409: {"error":"Active subscription already exists","code":"ACTIVE_SUBSCRIPTION_EXISTS"}
+```
+
+The button is labelled **Upgrade** so the user expects something to happen. Nothing does. There is no path to switch plans without first manually cancelling — and the cancel button is buried in the same card. UX dead-end.
+
+## Root cause
+
+`POST /api/v1/subscriptions/checkout` in `apps/api/src/modules/subscription/subscription.service.ts` rejects with 409 if the user already has an active sub. The endpoint was designed for first-time subscribe, not plan change. The UI calls it for both cases via the same "Upgrade / Subscribe" button.
+
+Stripe's standard pattern for plan change is:
+- Either redirect the user to the **Stripe Customer Portal** (Stripe-hosted UI for plan switch + cancel + invoice history), or
+- Call `subscriptions.update({ items: [{ id, price: newPriceId }] })` server-side and return success.
+
+Customer Portal is the standard, lowest-effort, lowest-risk option and matches our existing "Stripe-hosted checkout" pattern.
+
+## Decision
+
+Route plan-switch through the **Stripe Customer Portal**. Net change:
+
+- New API endpoint `POST /api/v1/subscriptions/portal` — creates a Stripe Billing Portal session for the current user, returns the URL.
+- UI: when user already has an active sub, "Upgrade / Subscribe" buttons on *other* plans become "Switch plan" → calls `/portal` → redirects to Stripe-hosted UI. The current plan card still shows "Cancel" → also routes through `/portal` (or keep the existing cancel endpoint — pick one and stay consistent).
+
+This sidesteps the entire plan-change matrix (proration, mid-period changes, downgrades) — Stripe handles all of it.
+
+## GIVEN / WHEN / THEN
+
+- **GIVEN** Ramesh has an active Pro sub **WHEN** he clicks "Switch plan" on Employer Medium **THEN** the UI POSTs `/api/v1/subscriptions/portal` and redirects him to a `billing.stripe.com/p/session/…` URL (no 409).
+- **GIVEN** Lisa has no subscription **WHEN** she clicks "Subscribe" on Pro Individual **THEN** the existing `/checkout` flow runs unchanged → Stripe Checkout (regression check — Spec 6 / Spec 11 unchanged for free users).
+- **GIVEN** any subscriber **WHEN** they click "Cancel subscription" **THEN** they're either (a) routed through the same Customer Portal session, or (b) the existing cancel endpoint still works — pick one, document, don't keep both.
+- **GIVEN** the API gets `POST /portal` from an unauthenticated user **THEN** 401.
+- **GIVEN** the API gets `POST /portal` from a user with no Stripe customer record **THEN** 400 with `code: NO_STRIPE_CUSTOMER` (or auto-create the customer — pick one, don't 500).
+
+## Slice checklist
+
+### L1 contract
+- [ ] New endpoint `POST /api/v1/subscriptions/portal` → returns `{ url: string }`.
+- [ ] Register schema in `apps/api/src/scripts/generate-openapi.ts`. Regen `docs/openapi.yaml` + `apps/ui/src/api-types.ts`.
+
+### API
+- [ ] `SubscriptionService.createPortalSession(userId)`:
+  - Look up user's `stripe_customer_id` (already on the subscription row).
+  - If missing → 400 `NO_STRIPE_CUSTOMER`.
+  - Call `stripe.billingPortal.sessions.create({ customer, return_url: <dashboard-billing-url-from-config> })`.
+  - Return `{ url: session.url }`.
+- [ ] Controller + route at `POST /subscriptions/portal`. `authenticate` middleware. No role/capability gate (any subscriber can manage their own billing).
+- [ ] L2 unit: mock Stripe SDK; assert `billingPortal.sessions.create` called with the correct customer ID and return_url.
+- [ ] L3 integration (Testcontainers): seed user with `stripe_customer_id`, hit endpoint, assert 200 + `url` field shape (`https://billing.stripe.com/…`); test the no-customer 400 path.
+
+### UI — `apps/ui/src/pages/BillingPage.tsx`
+- [ ] When `subscription.status` is `active` (or `trialing`) and the plan card is **not** the current plan:
+  - Button label: `Switch plan` (not `Upgrade` / `Subscribe`).
+  - On click: POST `/subscriptions/portal` → `window.location.href = res.url`.
+- [ ] Current plan card "Cancel subscription" button: same flow (POST `/portal` → redirect). Remove the existing cancel endpoint call from the UI if we're deprecating it; keep the API endpoint for now (deprecation is its own spec).
+- [ ] Free-tier users (no active sub): no UI change — "Subscribe" still goes to `/checkout` → Stripe Checkout.
+- [ ] Use generated types from `api-types.ts`; no hand-rolled interfaces.
+
+### L4 MSW tests — `apps/ui/src/__tests__/billing-switch-plan.test.tsx`
+- [ ] MSW: `/subscriptions/me` → active Pro sub. Render BillingPage.
+- [ ] Assert Employer Medium card shows `Switch plan` button (testid `billing-switch-employer-medium`), not `Upgrade`.
+- [ ] Click button → assert MSW intercepted `POST /subscriptions/portal` and `window.location.assign` was called with the mock URL.
+
+### L5 regression — `apps/regression/src/flows/20-billing-active-capabilities.spec.ts`
+- [ ] Extend: log in as ramesh, open /billing, click Switch on Employer Medium, assert the page navigates to a `billing.stripe.com` URL (don't actually transact — assert the redirect target host).
+
+### Deploys
+- [ ] `task dev:deploy:api` + `task dev:deploy:ui`. Manually verify in browser as ramesh — Switch plan → lands on Stripe portal page.
+
+## Invariants
+
+- `/checkout` endpoint contract unchanged — free users still flow through it.
+- No data model changes. `stripe_customer_id` already exists on subscription rows.
+- Stripe Customer Portal config (allowed plan changes, cancel rules) is configured in Stripe Dashboard, not in code. Document that prerequisite in the PR description.
+- No webhook changes — Stripe's existing `customer.subscription.updated` event already fires; our handler should already pick it up. If it doesn't, that's spec 48's territory, not this one.
+
+## Files
+
+- `apps/api/src/modules/subscription/subscription.service.ts` (add `createPortalSession`)
+- `apps/api/src/modules/subscription/subscription.controller.ts` (new handler)
+- `apps/api/src/modules/subscription/subscription.routes.ts` (new route)
+- `apps/api/src/modules/subscription/subscription.validation.ts` (response schema)
+- `apps/api/src/scripts/generate-openapi.ts` (register)
+- `apps/api/**/__tests__/`
+- `apps/ui/src/pages/BillingPage.tsx` (button labels + new handler)
+- `apps/ui/src/api-types.ts` (regenerated)
+- `apps/ui/src/__tests__/billing-switch-plan.test.tsx` (new)
+- `apps/regression/src/flows/20-billing-active-capabilities.spec.ts` (extend)
+- `docs/openapi.yaml` (regenerated)
+
+## Don't touch
+
+- `/checkout` endpoint — leave the contract alone.
+- Webhook handler — separate spec (48).
+- `apps/web/`, `apps/mobile/`.
+- Stripe Dashboard config (do that manually as a PR prerequisite, document it).
+
+## Stripe Dashboard prerequisite
+
+Before merging the PR: in Stripe Dashboard (test + live), enable Customer Portal and configure:
+- Allowed plan changes: any plan ↔ any plan (or a defined matrix per spec 11).
+- Cancel: enabled, immediate or at period end (pick — match our current cancel UX).
+- Update payment method: enabled.
+- Return URL: `https://review-dashboard.teczeed.com/billing` (dev), prod equivalent.

--- a/docs/specs/52-deploy-must-run-migrations.md
+++ b/docs/specs/52-deploy-must-run-migrations.md
@@ -1,0 +1,71 @@
+# Spec 52 — Deploys must auto-run pending migrations
+
+**Owner:** Open — Sreyash / Harsh / Hari (whoever picks it up first) · **Date:** 2026-04-20 · **Status:** Draft
+**Severity:** High — every missed migration becomes a runtime 500. Spec 50's `recruiter_blocks` bug is the most recent example; it sat in code for days because no one ran `task dev:migrate` after deploying.
+**Related:** Spec 02 (database), CLAUDE.md "always via task" rule.
+
+## Problem
+
+Today, `task dev:deploy:api` runs `node infra/scripts/deploy.js api dev`. That script does **not** run migrations. The Dockerfile's `CMD` is `node dist/server.js` — no migrate at boot. `apps/api/src/server.ts:28-30` even has the hook commented out:
+
+```ts
+// Migrations will be run here once the db/migrate module is implemented
+// const { migrateUp } = await import("./db/migrate.js");
+// await migrateUp();
+```
+
+`task dev:migrate` exists, but no deploy task depends on it. So whenever a developer ships a feature with a new migration, they have to remember a separate task. They forget. The dev DB drifts. Features 500.
+
+This has already bitten us at least once (spec 50, `recruiter_blocks` missing on dev). It will keep happening until deploy and migrate are coupled.
+
+## Decision
+
+**Option A (recommended) — Taskfile dependency.** Make `dev:deploy:api` and `prod:deploy:api` depend on `migrate`. Migration runs on the developer's machine through the Cloud SQL Auth Proxy *before* the new Cloud Run revision is rolled out. Safe at our scale (Cloud Run scales 0–2; old revision keeps serving until new one is healthy; migration is additive in 99% of cases).
+
+**Option B (rejected for now) — Boot-time migrate.** Uncomment `server.ts:28-30` so each new container migrates on startup. Cleaner long-term but races under concurrent revisions, and a slow migration stalls every cold start. Re-evaluate when we move past 0–2 instances.
+
+**Option C (rejected) — Cloud Run Job.** A pre-deploy migration job. Heavier infra than we need today.
+
+Pick A. Document the rationale in the PR.
+
+## GIVEN / WHEN / THEN
+
+- **GIVEN** the dev branch has a new migration **WHEN** a developer runs `task dev:deploy:api` **THEN** `task dev:migrate` runs first; on success the deploy proceeds; on migration failure the deploy aborts (no Cloud Run revision created).
+- **GIVEN** there are no pending migrations **WHEN** `task dev:deploy:api` runs **THEN** Umzug logs "no pending migrations", deploy proceeds, no errors.
+- **GIVEN** `task prod:deploy:api` is run **THEN** the same migrate-then-deploy flow happens against prod Cloud SQL.
+- **GIVEN** `task local:deploy:api` is added in the future **THEN** the same pattern applies (dev/prod parallel-label rule from CLAUDE.md).
+
+## Slice checklist
+
+- [ ] `Taskfile.dev.yml` — add `deps: [migrate]` to **both** `deploy:api` *and* `deploy:all`. Mirror in `Taskfile.prod.yml`. The dep does **not** cascade automatically: `deploy:all` runs `node deploy.js all dev`, which loops over services inside the script and bypasses the `deploy:api` task entirely (verified at `infra/scripts/deploy.js:472`). `deploy:web` and `deploy:ui` stay untouched (frontends don't migrate).
+- [ ] Verify `task dev:migrate` exits non-zero on failure (it should — Umzug throws on a bad migration). Manually: temporarily commit a broken migration on a throwaway branch, run `task dev:deploy:api`, confirm deploy never hits Cloud Run.
+- [ ] Update CLAUDE.md "Commands" → `dev:deploy:api` description: "Cloud Run deploy. Auto-runs `dev:migrate` first."
+- [ ] Update `docs/deployment-guide.md` to reflect the new behaviour (migration-then-deploy).
+- [ ] Remove the `// Migrations will be run here…` dead comment in `apps/api/src/server.ts:28-30` — or leave a one-liner pointing at this spec ("see spec 52 — migrations run via Taskfile dep, not at boot").
+
+## Invariants
+
+- Migrations run **before** the Cloud Run revision rollout, not after, not during.
+- Every `deploy:api` task across every env label (dev, prod, future local) carries the same `deps: [migrate]`.
+- No change to the deploy.js script itself — the chaining is at the Taskfile layer where dotenv scoping already lives.
+- No change to `local:server` / `local:dev` — local dev already has `local:bootstrap` which migrates explicitly. Don't double-migrate on every `local:dev`.
+
+## Files
+
+- `Taskfile.dev.yml`
+- `Taskfile.prod.yml`
+- `apps/api/src/server.ts` (delete or annotate dead comment)
+- `CLAUDE.md` (one-line update)
+- `docs/deployment-guide.md`
+
+## Don't touch
+
+- `infra/scripts/deploy.js` — keep it agnostic; chaining is the Taskfile's job.
+- `infra/scripts/run.sh` — same reason.
+- Boot-time migration in `server.ts` — explicitly out of scope (Option B is rejected).
+
+## Risk register
+
+- **Long migration blocks deploy.** Acceptable today; flag at code review if a migration looks like it'll take >30s. Future spec to handle: split heavy migrations or move them to a Cloud Run Job.
+- **Migration succeeds, deploy fails.** New schema is live, old code is still running, mismatch could surface as 500s on the old revision until the new revision rolls. Mitigation: keep migrations additive (add column nullable, not required). This is already best practice; not new with this spec.
+- **Developer's machine lacks Cloud SQL Auth Proxy.** `task dev:migrate` already starts the proxy. If it doesn't on a fresh setup, that's an unrelated bug to fix.

--- a/docs/specs/53-schema-code-drift.md
+++ b/docs/specs/53-schema-code-drift.md
@@ -1,0 +1,67 @@
+# Spec 53 — Schema-code drift: missing columns & extensions
+
+**Owner:** in-flight (this branch) · **Date:** 2026-04-20 · **Status:** Draft → fixing inline
+**Severity:** Blocker — recruiter search 500s + new `/subscriptions/portal` 500s on every fresh DB.
+**Related:** Spec 50 (recruiter_blocks — fixed but exposed this), Spec 51 (Stripe portal), Spec 12 (recruiter search).
+
+## Problem (live, reproducible on fresh local DB)
+
+After applying all 14 migrations on local Postgres:
+
+```bash
+$ curl -X POST localhost:6510/api/v1/recruiter/search -H 'authorization: Bearer …' -d '{"query":"ramesh"}'
+{"error":"column p.search_vector does not exist"}    # 500
+
+$ curl -X POST localhost:6510/api/v1/subscriptions/portal -H 'authorization: Bearer …' -d '{}'
+{"error":"column \"stripe_price_id\" does not exist"} # 500
+```
+
+## Root cause — three-way drift
+
+The repos write raw SQL referencing columns that:
+1. The migrations **don't create**
+2. The Sequelize model **doesn't declare**
+
+| Place | `subscriptions.stripe_price_id` | `subscriptions.billing_cycle` | `subscriptions.quantity` | `profiles.search_vector` | `pg_trgm` extension (for `p.location %` op) |
+|---|---|---|---|---|---|
+| Migrations | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Sequelize model | ❌ | ❌ | ❌ | n/a | n/a |
+| Repo SQL (`subscription.repo.ts`, `recruiter.repo.ts`) | ✅ reads/writes | ✅ reads/writes | ✅ reads/writes | ✅ filters on it | ✅ uses `%` operator |
+
+Likely history: someone wrote the queries assuming Sequelize sync would create the columns, but Umzug controls schema in this repo, not sync.
+
+## Fix — one additive migration
+
+New file `apps/api/src/db/migrations/20260420-0002-fix-schema-drift.ts`:
+
+1. `CREATE EXTENSION IF NOT EXISTS pg_trgm` — enables `%` similarity operator.
+2. `ALTER TABLE subscriptions ADD COLUMN stripe_price_id varchar(255)` — nullable, populated by webhook handler when Stripe assigns the price.
+3. `ALTER TABLE subscriptions ADD COLUMN billing_cycle varchar(20)` — values `monthly | annual`, nullable for free tier rows.
+4. `ALTER TABLE subscriptions ADD COLUMN quantity integer NOT NULL DEFAULT 1` — for per-seat / per-location billing.
+5. `ALTER TABLE profiles ADD COLUMN search_vector tsvector` — full-text search across headline + bio + industry + location.
+6. `CREATE INDEX profiles_search_vector_idx ON profiles USING gin (search_vector)`.
+7. `CREATE INDEX profiles_location_trgm_idx ON profiles USING gin (location gin_trgm_ops)` — supports `p.location %` queries.
+8. Backfill `UPDATE profiles SET search_vector = to_tsvector('english', coalesce(headline,'') || ' ' || coalesce(bio,'') || ' ' || coalesce(industry,'') || ' ' || coalesce(location,''))`.
+9. Trigger to auto-update `search_vector` on insert/update.
+
+`down()` reverses each step in reverse order.
+
+Also update **`apps/api/src/modules/subscription/subscription.model.ts`** to declare `stripePriceId`, `billingCycle`, `quantity` on `SubscriptionAttributes` + `Subscription.init` so Sequelize stays in sync with the DB.
+
+## GIVEN / WHEN / THEN
+
+- **GIVEN** a fresh DB **WHEN** `task local:migrate` runs **THEN** the new columns + indexes + trigger exist.
+- **GIVEN** Rachel logged in **WHEN** she POSTs `/recruiter/search {"query":"ramesh"}` **THEN** API returns 200 with results, not 500.
+- **GIVEN** Ramesh (active subscriber, with a `stripe_customer_id` row) **WHEN** he POSTs `/subscriptions/portal` **THEN** API returns 200 with a `portalUrl` (assuming Stripe Portal is configured — separate from this spec).
+- **GIVEN** a profile is updated (headline/bio/industry/location) **THEN** `search_vector` is auto-recomputed by the trigger.
+
+## Don't touch
+
+- The repo SQL — it's correct, the schema was wrong.
+- Sequelize sync (still off — Umzug only).
+- Stripe Portal config or webhooks — that's Spec 54.
+
+## Files
+
+- `apps/api/src/db/migrations/20260420-0002-fix-schema-drift.ts` (new)
+- `apps/api/src/modules/subscription/subscription.model.ts` (declare new fields)


### PR DESCRIPTION
## Summary

- **Spec 53** — fixes schema-code drift on `subscriptions` + `profiles` tables. Repos write SQL referencing columns no migration ever created; recruiter search and the new `/subscriptions/portal` endpoint (spec 51) 500'd on every fresh DB. Pre-existing on dev too — masked by manual schema patches.
- **Local port reorg** to 651x range (Cloud Run still uses 8080 separately): API 6510, UI 6513, Web 6514, Postgres 6519. New `local:dev:ui` and `local:dev:web` tasks.

## Migrations (additive, idempotent)

- `20260420-0002-fix-schema-drift.ts` — pg_trgm extension; `profiles.search_vector` (tsvector) + GIN index + auto-refresh trigger; `profiles.location` trigram GIN index; `subscriptions.{stripe_price_id, billing_cycle, quantity}`.
- `20260420-0003-fix-schema-drift-followup.ts` — `subscriptions.{cancel_at_period_end, cancelled_at}`.
- Sequelize `Subscription` model declares the 5 new fields.

## Verified locally

| Bug | Result |
|---|---|
| Spec 49 `/profiles/me` 403 for EMPLOYER/RECRUITER | ✅ 200/404 (no longer 403) |
| Spec 50 recruiter search 500 (`recruiter_blocks` + `search_vector`) | ✅ Returns 200 with results |
| Spec 51 portal 409 + missing columns | ✅ Schema layer green; only fails at Stripe API in local (placeholder key) |
| Spec 52 deploy auto-migrate | ✅ `task local:migrate` picked up + applied 2 pending migrations |

## Stripe (separate but related)

- ✅ Customer Portal config created via API (cancel + payment_method + invoice_history; subscription_update intentionally off — needs product restructure)
- ✅ Webhook endpoint created → `https://review-api.teczeed.com/api/v1/subscriptions/webhook`
- ✅ STRIPE_WEBHOOK_SECRET updated in `.env.dev` + pushed to GCP Secret Manager

## Test plan

- [ ] Merge → `task dev:deploy:all` (auto-migrates via spec 52)
- [ ] Re-run dev verification: profiles/me as james & rachel (no 403), recruiter search as rachel returns results, portal endpoint returns Stripe URL