### PR TITLE
fix(api): bump URL varchar(512) → TEXT (unblocks Google sign-in)

### DIFF
--- a/apps/api/src/db/migrations/20260420-0004-bump-varchar-512-to-text.ts
+++ b/apps/api/src/db/migrations/20260420-0004-bump-varchar-512-to-text.ts
@@ -1,0 +1,26 @@
+import type { Migration } from "../umzug.js";
+
+// Bump varchar(512) columns that hold third-party URLs (Google profile pictures,
+// signed cloud-storage URLs) to TEXT. Google profile picture URLs from
+// `lh3.googleusercontent.com` regularly exceed 512 chars once size/quality
+// params are appended, causing 500 ("value too long for type character
+// varying(512)") on Google sign-in.
+
+export const up: Migration = async ({ context: sequelize }) => {
+  await sequelize.query(`ALTER TABLE users         ALTER COLUMN avatar_url   TYPE text`);
+  await sequelize.query(`ALTER TABLE profiles      ALTER COLUMN qr_code_url  TYPE text`);
+  await sequelize.query(`ALTER TABLE review_media  ALTER COLUMN media_url    TYPE text`);
+  await sequelize.query(`ALTER TABLE organizations ALTER COLUMN logo_url     TYPE text`);
+  await sequelize.query(`ALTER TABLE organizations ALTER COLUMN website      TYPE text`);
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+  // Note: down requires every existing value to fit in 512 chars; will fail
+  // if any post-migration value exceeds that. Acceptable for a recoverable
+  // rollback during local dev.
+  await sequelize.query(`ALTER TABLE users         ALTER COLUMN avatar_url   TYPE varchar(512)`);
+  await sequelize.query(`ALTER TABLE profiles      ALTER COLUMN qr_code_url  TYPE varchar(512)`);
+  await sequelize.query(`ALTER TABLE review_media  ALTER COLUMN media_url    TYPE varchar(512)`);
+  await sequelize.query(`ALTER TABLE organizations ALTER COLUMN logo_url     TYPE varchar(512)`);
+  await sequelize.query(`ALTER TABLE organizations ALTER COLUMN website      TYPE varchar(512)`);
+};


### PR DESCRIPTION
Google profile picture URLs from `lh3.googleusercontent.com` regularly exceed 512 chars, causing `500 value too long for type character varying(512)` on `/auth/exchange-token` during first Google sign-in.

Migration bumps `users.avatar_url` + `profiles.qr_code_url` + `review_media.media_url` + `organizations.{logo_url,website}` to TEXT (all URL-holding fields).

Applied to local + dev Cloud SQL. After merge, dev re-deploy will ensure no regressions.